### PR TITLE
CookIT now working on iOS as well as on Android

### DIFF
--- a/js/components/CustomFont.js
+++ b/js/components/CustomFont.js
@@ -20,7 +20,7 @@ export default class CustomFont extends React.Component {
 
     render() {
         if (this.state.loading) {
-            return <ActivityIndicator />
+            return null
         }
         return (
             <Text style={styles.defaultStyle}>


### PR DESCRIPTION
The loading animation of ActivityIndicator is never shown because the text loads in an instant.
If null is returned the app runs on Android as well because Android doesn't allow Views inside Text components.